### PR TITLE
Fix ruby def class syntax highlight

### DIFF
--- a/src/syntax.mjs
+++ b/src/syntax.mjs
@@ -103,7 +103,9 @@ export default [
          'keyword.other.class.fileds',
          'source.toml entity.other.attribute-name',
          'source.css entity.name.tag.custom',
-         'sharing.modifier'
+         'sharing.modifier',
+         'keyword.control.class.ruby',
+         'keyword.control.def.ruby'
       ],
       settings: {
          foreground: '#df769b'
@@ -658,7 +660,9 @@ export default [
          'entity.name.function.definition.special.constructor',
          'entity.name.function.definition.special.member.destructor.',
          'meta.function.parameters variable punctuation.definition.variable.php',
-         'source.wsd keyword.other.activity'
+         'source.wsd keyword.other.activity',
+         'keyword.control.class.ruby',
+         'keyword.control.def.ruby'
       ],
       settings: {
          fontStyle: 'bold'

--- a/themes/azureus.json
+++ b/themes/azureus.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#df769b"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/bordo.json
+++ b/themes/bordo.json
@@ -375,7 +375,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#df769b"
@@ -931,7 +933,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/hibernus.json
+++ b/themes/hibernus.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#ff5792"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/lilac.json
+++ b/themes/lilac.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#ff5792"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/lux.json
+++ b/themes/lux.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#ff5792"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/minimus.json
+++ b/themes/minimus.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#c88da2"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/noctis.json
+++ b/themes/noctis.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#df769b"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/obscuro.json
+++ b/themes/obscuro.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#df769b"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/sereno.json
+++ b/themes/sereno.json
@@ -376,7 +376,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#df769b"
@@ -932,7 +934,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/uva.json
+++ b/themes/uva.json
@@ -375,7 +375,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#df769b"
@@ -931,7 +933,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"

--- a/themes/viola.json
+++ b/themes/viola.json
@@ -375,7 +375,9 @@
             "keyword.other.class.fileds",
             "source.toml entity.other.attribute-name",
             "source.css entity.name.tag.custom",
-            "sharing.modifier"
+            "sharing.modifier",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "foreground": "#df769b"
@@ -931,7 +933,9 @@
             "entity.name.function.definition.special.constructor",
             "entity.name.function.definition.special.member.destructor.",
             "meta.function.parameters variable punctuation.definition.variable.php",
-            "source.wsd keyword.other.activity"
+            "source.wsd keyword.other.activity",
+            "keyword.control.class.ruby",
+            "keyword.control.def.ruby"
          ],
          "settings": {
             "fontStyle": "bold"


### PR DESCRIPTION
This makes Ruby's `class` and `def` syntax highlighting match their `end`.

Before
<img width="713" alt="Screen Shot 2019-11-12 at 2 34 48 PM" src="https://user-images.githubusercontent.com/6521018/68648868-59350b00-055c-11ea-8867-ca949b468b05.png">

After
<img width="711" alt="Screen Shot 2019-11-12 at 2 50 42 PM" src="https://user-images.githubusercontent.com/6521018/68649076-d6608000-055c-11ea-9aeb-9f870d371b64.png">

Btw thanks for making these excellent themes!