### PR TITLE
Host color-preview images within the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
-   <img width="170" src="https://raw.githubusercontent.com/liviuschera/noctis/master/images/logo.png" />
+   <img width="170" src="https://github.com/liviuschera/noctis/blob/master/images/logo.png?raw=true" />
 </p>
 
 <p align="center">
-   <img width="400" src="https://github.com/liviuschera/noctis/raw/master/images/noctisLogo.png" />
+   <img width="400" src="https://github.com/liviuschera/noctis/blob/master/images/noctisLogo.png?raw=true" />
 </p>
 
 Noctis is a collection of light & dark themes with a well balanced blend of warm and cold **medium contrast** colors.
@@ -35,39 +35,39 @@ Noctis comes in 11 versions, 8 are dark and 3 are light.
 
 ## Noctis
 
-![Noctis Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctis.png)
+![Noctis Screenshot](/images/noctis.png)
 
 ## Noctis Azureus
 
-![Noctis Azureus Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctisAzureus.png)
+![Noctis Azureus Screenshot](/images/noctisAzureus.png)
 
 ## Noctis Bordo
 
-![Noctis Bordo Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctisBordo.png)
+![Noctis Bordo Screenshot](/images/noctisBordo.png)
 
 ## Noctis Minimus
 
-![Noctis Minimus Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctisMinimus.png)
+![Noctis Minimus Screenshot](/images/noctisMinimus.png)
 
 ## Noctis Uva
 
-![Noctis Uva Screenshot](https://github.com/liviuschera/noctis/raw/master/images/NoctisUva.png)
+![Noctis Uva Screenshot](/images/NoctisUva.png)
 
 ## Noctis Viola
 
-![Noctis Viola Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctisViola.png)
+![Noctis Viola Screenshot](/images/noctisViola.png)
 
 ## Noctis Lux
 
-![Noctis Lux Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctisLux.png)
+![Noctis Lux Screenshot](/images/noctisLux.png)
 
 ## Noctis Lilac
 
-![Noctis Lilac Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctisLilac.png)
+![Noctis Lilac Screenshot](/images/noctisLilac.png)
 
 ## Noctis Hibernus
 
-![Noctis Hibernus Screenshot](https://github.com/liviuschera/noctis/raw/master/images/noctisHibernus.png)
+![Noctis Hibernus Screenshot](/images/noctisHibernus.png)
 
 </div>
 
@@ -141,58 +141,58 @@ The color names were matched using the excellent online tools [Name that Color](
 
 ### Standard Colors
 
-| Color           | Hex Code                                                           | Used for:                                                 |
-| --------------- | ------------------------------------------------------------------ | --------------------------------------------------------- |
-| Eucalyptus      | ![#49e9a6](https://via.placeholder.com/15/49e9a6/000000?text=+) `#49e9a6` | Strings                                                   |
-| Mountain Meadow | ![#16b673](https://via.placeholder.com/15/16b673/000000?text=+) `#16b673` | Interpolated Strings                                      |
-| Horizon         | ![#5b858b](https://via.placeholder.com/15/5b858b/000000?text=+) `#5b858b` | Comments for default theme                                |
-| Smalt Blue      | ![#507b95](https://via.placeholder.com/15/507b95/000000?text=+) `#507b95` | Comments for _Azureus_ variant                            |
-| Kimberly        | ![#716c93](https://via.placeholder.com/15/716c93/000000?text=+) `#716c93` | Comments for _Uva_ variant                                |
-| Trendy Pink     | ![#7f659a](https://via.placeholder.com/15/7f659a/000000?text=+) `#7f659a` | Comments for _Viola_ variant                              |
-| Eastern Blue    | ![#16a3b6](https://via.placeholder.com/15/16a3b6/000000?text=+) `#16a3b6` | Function Calls                                            |
-| Turcoise        | ![#49d6e9](https://via.placeholder.com/15/49d6e9/000000?text=+) `#49d6e9` | Method Calls                                              |
-| Picton Blue     | ![#49ace9](https://via.placeholder.com/15/49ace9/000000?text=+) `#49ace9` | Code that needs to stand out                              |
-| Cornflower Blue | ![#7060eb](https://via.placeholder.com/15/7060eb/000000?text=+) `#7060eb` | Numbers & Booleans                                        |
-| Pale Violet Red | ![#df769b](https://via.placeholder.com/15/df769b/000000?text=+) `#df769b` | Keywords & Operators                                      |
-| Cinnabar        | ![#e66533](https://via.placeholder.com/15/e66533/000000?text=+) `#e66533` | Function & Variable Declaration, Tags & `this`            |
-| Japonica        | ![#d67e5c](https://via.placeholder.com/15/d67e5c/000000?text=+) `#d67e5c` | Object properties, ID selectors in CSS & Type annotations |
-| Galliano        | ![#d5971a](https://via.placeholder.com/15/d5971a/000000?text=+) `#d5971a` | Attributes, Constants                                     |
-| Gold Sand       | ![#e4b781](https://via.placeholder.com/15/e4b781/000000?text=+) `#e4b781` | Variables & Parameters                                    |
+| Color           | Hex Code                                                | Used for:                                                 |
+| --------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| Eucalyptus      | ![#49e9a6](/images/color-previews/49e9a6.svg) `#49e9a6` | Strings                                                   |
+| Mountain Meadow | ![#16b673](/images/color-previews/16b673.svg) `#16b673` | Interpolated Strings                                      |
+| Horizon         | ![#5b858b](/images/color-previews/5b858b.svg) `#5b858b` | Comments for default theme                                |
+| Smalt Blue      | ![#507b95](/images/color-previews/507b95.svg) `#507b95` | Comments for _Azureus_ variant                            |
+| Kimberly        | ![#716c93](/images/color-previews/716c93.svg) `#716c93` | Comments for _Uva_ variant                                |
+| Trendy Pink     | ![#7f659a](/images/color-previews/7f659a.svg) `#7f659a` | Comments for _Viola_ variant                              |
+| Eastern Blue    | ![#16a3b6](/images/color-previews/16a3b6.svg) `#16a3b6` | Function Calls                                            |
+| Turcoise        | ![#49d6e9](/images/color-previews/49d6e9.svg) `#49d6e9` | Method Calls                                              |
+| Picton Blue     | ![#49ace9](/images/color-previews/49ace9.svg) `#49ace9` | Code that needs to stand out                              |
+| Cornflower Blue | ![#7060eb](/images/color-previews/7060eb.svg) `#7060eb` | Numbers & Booleans                                        |
+| Pale Violet Red | ![#df769b](/images/color-previews/df769b.svg) `#df769b` | Keywords & Operators                                      |
+| Cinnabar        | ![#e66533](/images/color-previews/e66533.svg) `#e66533` | Function & Variable Declaration, Tags & `this`            |
+| Japonica        | ![#d67e5c](/images/color-previews/d67e5c.svg) `#d67e5c` | Object properties, ID selectors in CSS & Type annotations |
+| Galliano        | ![#d5971a](/images/color-previews/d5971a.svg) `#d5971a` | Attributes, Constants                                     |
+| Gold Sand       | ![#e4b781](/images/color-previews/e4b781.svg) `#e4b781` | Variables & Parameters                                    |
 
 ### Minimus Colors
 
-| Color         | Hex Code                                                           | Used for:                                                 |
-| ------------- | ------------------------------------------------------------------ | --------------------------------------------------------- |
-| Silver Tree   | ![#70c27f](https://via.placeholder.com/15/70c27f/000000?text=+) `#70c27f` | Strings                                                   |
-| Viridian      | ![#3f8d6c](https://via.placeholder.com/15/3f8d6c/000000?text=+) `#3f8d6c` | Interpolated Strings                                      |
-| Hoki          | ![#5e7887](https://via.placeholder.com/15/5e7887/000000?text=+) `#5e7887` | Comments                                                  |
-| Ming          | ![#3f848d](https://via.placeholder.com/15/3f848d/000000?text=+) `#3f848d` | Function Calls                                            |
-| Glacier       | ![#72b7c0](https://via.placeholder.com/15/72b7c0/000000?text=+) `#72b7c0` | Method Calls                                              |
-| Fountain Blue | ![#5998c0](https://via.placeholder.com/15/5998c0/000000?text=+) `#5998c0` | Code that needs to stand out                              |
-| Chetwode Blue | ![#7068B1](https://via.placeholder.com/15/7068B1/000000?text=+) `#7068B1` | Numbers & Booleans                                        |
-| Viola         | ![#c88da2](https://via.placeholder.com/15/c88da2/000000?text=+) `#c88da2` | Keywords & Operators                                      |
-| Antique Brass | ![#c37455](https://via.placeholder.com/15/c37455/000000?text=+) `#c37455` | Function & Variable Declaration, Tags & `this`            |
-| Contessa      | ![#be856f](https://via.placeholder.com/15/be856f/000000?text=+) `#be856f` | Object properties, ID selectors in CSS & Type annotations |
-| Driftwood     | ![#b0904f](https://via.placeholder.com/15/b0904f/000000?text=+) `#b0904f` | Attributes, Constants                                     |
-| Tan           | ![#d3b692](https://via.placeholder.com/15/d3b692/000000?text=+) `#d3b692` | Variables & Parameters                                    |
+| Color         | Hex Code                                                | Used for:                                                 |
+| ------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| Silver Tree   | ![#70c27f](/images/color-previews/70c27f.svg) `#70c27f` | Strings                                                   |
+| Viridian      | ![#3f8d6c](/images/color-previews/3f8d6c.svg) `#3f8d6c` | Interpolated Strings                                      |
+| Hoki          | ![#5e7887](/images/color-previews/5e7887.svg) `#5e7887` | Comments                                                  |
+| Ming          | ![#3f848d](/images/color-previews/3f848d.svg) `#3f848d` | Function Calls                                            |
+| Glacier       | ![#72b7c0](/images/color-previews/72b7c0.svg) `#72b7c0` | Method Calls                                              |
+| Fountain Blue | ![#5998c0](/images/color-previews/5998c0.svg) `#5998c0` | Code that needs to stand out                              |
+| Chetwode Blue | ![#7068B1](/images/color-previews/7068B1.svg) `#7068B1` | Numbers & Booleans                                        |
+| Viola         | ![#c88da2](/images/color-previews/c88da2.svg) `#c88da2` | Keywords & Operators                                      |
+| Antique Brass | ![#c37455](/images/color-previews/c37455.svg) `#c37455` | Function & Variable Declaration, Tags & `this`            |
+| Contessa      | ![#be856f](/images/color-previews/be856f.svg) `#be856f` | Object properties, ID selectors in CSS & Type annotations |
+| Driftwood     | ![#b0904f](/images/color-previews/b0904f.svg) `#b0904f` | Attributes, Constants                                     |
+| Tan           | ![#d3b692](/images/color-previews/d3b692.svg) `#d3b692` | Variables & Parameters                                    |
 
 ### Light Themes Colors
 
-| Color            | Hex Code                                                           | Used for:                                                 |
-| ---------------- | ------------------------------------------------------------------ | --------------------------------------------------------- |
-| Jade             | ![#00b368](https://via.placeholder.com/15/00b368/000000?text=+) `#00b368` | Strings                                                   |
-| Green Haze       | ![#009456](https://via.placeholder.com/15/009456/000000?text=+) `#009456` | Interpolated Strings                                      |
-| Cascade          | ![#8ca6a6](https://via.placeholder.com/15/8ca6a6/000000?text=+) `#8ca6a6` | Comments for _Lux_ & _Hibernus_ variant                   |
-| Amethyst Smoke   | ![#9995b7](https://via.placeholder.com/15/9995b7/000000?text=+) `#9995b7` | Comments for _Lilac_ variant                              |
-| Bondi Blue       | ![#0095a8](https://via.placeholder.com/15/0095a8/000000?text=+) `#0095a8` | Function Calls                                            |
-| Robin's Egg Blue | ![#00bdd6](https://via.placeholder.com/15/00bdd6/000000?text=+) `#00bdd6` | Method Calls                                              |
-| Azure Radiance   | ![#0094f0](https://via.placeholder.com/15/0094f0/000000?text=+) `#0094f0` | Code that needs to stand out                              |
-| Electric Violet  | ![#5842ff](https://via.placeholder.com/15/5842ff/000000?text=+) `#5842ff` | Numbers & Booleans                                        |
-| PBrink Pink      | ![#ff5792](https://via.placeholder.com/15/ff5792/000000?text=+) `#ff5792` | Keywords & Operators                                      |
-| Trinidad         | ![#e64100](https://via.placeholder.com/15/e64100/000000?text=+) `#e64100` | Function & Variable Declaration, Tags & `this`            |
-| Santa Fe         | ![#b3694d](https://via.placeholder.com/15/b3694d/000000?text=+) `#b3694d` | Object properties, ID selectors in CSS & Type annotations |
-| Dark Goldenrod   | ![#a88c00](https://via.placeholder.com/15/a88c00/000000?text=+) `#a88c00` | Attributes, Constants                                     |
-| Yellow Sea       | ![#f49725](https://via.placeholder.com/15/f49725/000000?text=+) `#f49725` | Variables & Parameters                                    |
+| Color            | Hex Code                                                | Used for:                                                 |
+| ---------------- | ------------------------------------------------------- | --------------------------------------------------------- |
+| Jade             | ![#00b368](/images/color-previews/00b368.svg) `#00b368` | Strings                                                   |
+| Green Haze       | ![#009456](/images/color-previews/009456.svg) `#009456` | Interpolated Strings                                      |
+| Cascade          | ![#8ca6a6](/images/color-previews/8ca6a6.svg) `#8ca6a6` | Comments for _Lux_ & _Hibernus_ variant                   |
+| Amethyst Smoke   | ![#9995b7](/images/color-previews/9995b7.svg) `#9995b7` | Comments for _Lilac_ variant                              |
+| Bondi Blue       | ![#0095a8](/images/color-previews/0095a8.svg) `#0095a8` | Function Calls                                            |
+| Robin's Egg Blue | ![#00bdd6](/images/color-previews/00bdd6.svg) `#00bdd6` | Method Calls                                              |
+| Azure Radiance   | ![#0094f0](/images/color-previews/0094f0.svg) `#0094f0` | Code that needs to stand out                              |
+| Electric Violet  | ![#5842ff](/images/color-previews/5842ff.svg) `#5842ff` | Numbers & Booleans                                        |
+| Brink Pink       | ![#ff5792](/images/color-previews/ff5792.svg) `#ff5792` | Keywords & Operators                                      |
+| Trinidad         | ![#e64100](/images/color-previews/e64100.svg) `#e64100` | Function & Variable Declaration, Tags & `this`            |
+| Santa Fe         | ![#b3694d](/images/color-previews/b3694d.svg) `#b3694d` | Object properties, ID selectors in CSS & Type annotations |
+| Dark Goldenrod   | ![#a88c00](/images/color-previews/a88c00.svg) `#a88c00` | Attributes, Constants                                     |
+| Yellow Sea       | ![#f49725](/images/color-previews/f49725.svg) `#f49725` | Variables & Parameters                                    |
 
 ## Installation
 
@@ -212,9 +212,15 @@ Happy hacking!
 
 ## Contributors
 
-| [![Matteo Campinoti](https://avatars0.githubusercontent.com/u/5142004?s=85)](https://github.com/MatteoCampinoti94) | [![Draevin](https://avatars2.githubusercontent.com/u/25379577?s=85)](https://github.com/draevin) | [![Will Hoskings](https://avatars0.githubusercontent.com/u/49915996?s=85)](https://github.com/resynth1943) | [![Dang Trung Kien](https://avatars2.githubusercontent.com/u/6521018?s=85)](https://github.com/kiendang) | [![CertainLach](https://avatars3.githubusercontent.com/u/6235312?s=85)](https://github.com/CertainLach) | [![Dustin Beecher](https://avatars.githubusercontent.com/u/65888560?s=85)](https://github.com/dustinbeecher) |
-| :--------------------------------------------------------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------: |
-|                                [Matteo Campinoti](https://github.com/MatteoCampinoti94)                                |                                [Draevin](https://github.com/draevin)                                 |                                [Will Hoskings](https://github.com/resynth1943)                                 |                                [Dang Trung Kien](https://github.com/kiendang)                                |                                [CertainLach](https://github.com/CertainLach)                                |                                [Dustin Beecher](https://github.com/dustinbeecher)                                |
+|  |  |
+|---|---|
+| [![Matteo Campinoti](https://avatars.githubusercontent.com/u/5142004?s=85)](https://github.com/MatteoCampinoti94) | [Matteo Campinoti](https://github.com/MatteoCampinoti94) |
+| [![Draevin](https://avatars.githubusercontent.com/u/25379577?s=85)](https://github.com/draevin) | [Draevin](https://github.com/draevin) |
+| <a href="https://github.com/resynth1943"><img width="85" src="https://avatars.githubusercontent.com/u/49915996" alt="Will Hoskings" /></a> | [Will Hoskings](https://github.com/resynth1943) |
+| [![Dang Trung Kien](https://avatars.githubusercontent.com/u/6521018?s=85)](https://github.com/kiendang) | [Dang Trung Kien](https://github.com/kiendang) |
+| [![CertainLach](https://avatars.githubusercontent.com/u/6235312?s=85)](https://github.com/CertainLach) | [CertainLach](https://github.com/CertainLach) |
+| [![Dustin Beecher](https://avatars.githubusercontent.com/u/65888560?s=85)](https://github.com/dustinbeecher) | [Dustin Beecher](https://github.com/dustinbeecher) |
+| [![Jatin Sanghvi](https://avatars.githubusercontent.com/u/20547963?s=85)](https://github.com/JatinSanghvi) | [Jatin Sanghvi](https://github.com/JatinSanghvi) |
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <p align="center">
-   <img width="170" src="https://github.com/liviuschera/noctis/blob/master/images/logo.png?raw=true" />
+   <img width="170" src="/images/logo.png" />
 </p>
 
 <p align="center">
-   <img width="400" src="https://github.com/liviuschera/noctis/blob/master/images/noctisLogo.png?raw=true" />
+   <img width="400" src="/images/noctisLogo.png" />
 </p>
 
 Noctis is a collection of light & dark themes with a well balanced blend of warm and cold **medium contrast** colors.

--- a/images/color-previews/009456.svg
+++ b/images/color-previews/009456.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#009456" width="15" height="15" />
+</svg>

--- a/images/color-previews/0094f0.svg
+++ b/images/color-previews/0094f0.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#0094f0" width="15" height="15" />
+</svg>

--- a/images/color-previews/0095a8.svg
+++ b/images/color-previews/0095a8.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#0095a8" width="15" height="15" />
+</svg>

--- a/images/color-previews/00b368.svg
+++ b/images/color-previews/00b368.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#00b368" width="15" height="15" />
+</svg>

--- a/images/color-previews/00bdd6.svg
+++ b/images/color-previews/00bdd6.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#00bdd6" width="15" height="15" />
+</svg>

--- a/images/color-previews/16a3b6.svg
+++ b/images/color-previews/16a3b6.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#16a3b6" width="15" height="15" />
+</svg>

--- a/images/color-previews/16b673.svg
+++ b/images/color-previews/16b673.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#16b673" width="15" height="15" />
+</svg>

--- a/images/color-previews/3f848d.svg
+++ b/images/color-previews/3f848d.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#3f848d" width="15" height="15" />
+</svg>

--- a/images/color-previews/3f8d6c.svg
+++ b/images/color-previews/3f8d6c.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#3f8d6c" width="15" height="15" />
+</svg>

--- a/images/color-previews/49ace9.svg
+++ b/images/color-previews/49ace9.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#49ace9" width="15" height="15" />
+</svg>

--- a/images/color-previews/49d6e9.svg
+++ b/images/color-previews/49d6e9.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#49d6e9" width="15" height="15" />
+</svg>

--- a/images/color-previews/49e9a6.svg
+++ b/images/color-previews/49e9a6.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#49e9a6" width="15" height="15" />
+</svg>

--- a/images/color-previews/507b95.svg
+++ b/images/color-previews/507b95.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#507b95" width="15" height="15" />
+</svg>

--- a/images/color-previews/5842ff.svg
+++ b/images/color-previews/5842ff.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#5842ff" width="15" height="15" />
+</svg>

--- a/images/color-previews/5998c0.svg
+++ b/images/color-previews/5998c0.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#5998c0" width="15" height="15" />
+</svg>

--- a/images/color-previews/5b858b.svg
+++ b/images/color-previews/5b858b.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#5b858b" width="15" height="15" />
+</svg>

--- a/images/color-previews/5e7887.svg
+++ b/images/color-previews/5e7887.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#5e7887" width="15" height="15" />
+</svg>

--- a/images/color-previews/7060eb.svg
+++ b/images/color-previews/7060eb.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#7060eb" width="15" height="15" />
+</svg>

--- a/images/color-previews/7068B1.svg
+++ b/images/color-previews/7068B1.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#7068B1" width="15" height="15" />
+</svg>

--- a/images/color-previews/70c27f.svg
+++ b/images/color-previews/70c27f.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#70c27f" width="15" height="15" />
+</svg>

--- a/images/color-previews/716c93.svg
+++ b/images/color-previews/716c93.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#716c93" width="15" height="15" />
+</svg>

--- a/images/color-previews/72b7c0.svg
+++ b/images/color-previews/72b7c0.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#72b7c0" width="15" height="15" />
+</svg>

--- a/images/color-previews/7f659a.svg
+++ b/images/color-previews/7f659a.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#7f659a" width="15" height="15" />
+</svg>

--- a/images/color-previews/8ca6a6.svg
+++ b/images/color-previews/8ca6a6.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#8ca6a6" width="15" height="15" />
+</svg>

--- a/images/color-previews/9995b7.svg
+++ b/images/color-previews/9995b7.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#9995b7" width="15" height="15" />
+</svg>

--- a/images/color-previews/a88c00.svg
+++ b/images/color-previews/a88c00.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#a88c00" width="15" height="15" />
+</svg>

--- a/images/color-previews/b0904f.svg
+++ b/images/color-previews/b0904f.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#b0904f" width="15" height="15" />
+</svg>

--- a/images/color-previews/b3694d.svg
+++ b/images/color-previews/b3694d.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#b3694d" width="15" height="15" />
+</svg>

--- a/images/color-previews/be856f.svg
+++ b/images/color-previews/be856f.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#be856f" width="15" height="15" />
+</svg>

--- a/images/color-previews/c37455.svg
+++ b/images/color-previews/c37455.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#c37455" width="15" height="15" />
+</svg>

--- a/images/color-previews/c88da2.svg
+++ b/images/color-previews/c88da2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#c88da2" width="15" height="15" />
+</svg>

--- a/images/color-previews/d3b692.svg
+++ b/images/color-previews/d3b692.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#d3b692" width="15" height="15" />
+</svg>

--- a/images/color-previews/d5971a.svg
+++ b/images/color-previews/d5971a.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#d5971a" width="15" height="15" />
+</svg>

--- a/images/color-previews/d67e5c.svg
+++ b/images/color-previews/d67e5c.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#d67e5c" width="15" height="15" />
+</svg>

--- a/images/color-previews/df769b.svg
+++ b/images/color-previews/df769b.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#df769b" width="15" height="15" />
+</svg>

--- a/images/color-previews/e4b781.svg
+++ b/images/color-previews/e4b781.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#e4b781" width="15" height="15" />
+</svg>

--- a/images/color-previews/e64100.svg
+++ b/images/color-previews/e64100.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#e64100" width="15" height="15" />
+</svg>

--- a/images/color-previews/e66533.svg
+++ b/images/color-previews/e66533.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#e66533" width="15" height="15" />
+</svg>

--- a/images/color-previews/f49725.svg
+++ b/images/color-previews/f49725.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#f49725" width="15" height="15" />
+</svg>

--- a/images/color-previews/ff5792.svg
+++ b/images/color-previews/ff5792.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="15" height="15">
+  <rect fill="#ff5792" width="15" height="15" />
+</svg>


### PR DESCRIPTION
At present, the color preview images are not showing up in GitHub Readme file and in Visual Studio Code Marketplace, most probably due to throttling policy set by Placeholder.com (see Rule 1 on https://placeholder.com/rules/). Since GitHub proxies all request to images hosted on external sites through its github-camo servers (see GitHub documentation: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls), the Placeholder.com site treats request emitting from different user browsers as arriving from single user and throttles them. The PR stores the images as SVG files inside the repo to fix this situation.