### PR TITLE
Azureus: Improve editorHoverWidget contrast with editor background

### DIFF
--- a/src/workbench/azureus.mjs
+++ b/src/workbench/azureus.mjs
@@ -153,7 +153,7 @@ export default syntax => ({
     // ---------------------------
     "editorWidget.background": "#09334e",
     "editorWidget.border": "#0f1315",
-    "editorHoverWidget.background": "#002942",
+    "editorHoverWidget.background": "#0b3c5b",
     "editorHoverWidget.border": "#0f1315",
     "editorSuggestWidget.background": "#002942",
     "editorSuggestWidget.border": "#0f1315",


### PR DESCRIPTION
Change color of `editorHoverWidget.background` to use color used by `menu.selectionBackground` which is easier to distinguish from the editor background color.

Fixes #87 